### PR TITLE
add Foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "description": "react, react-router, hot-reload, sass.",
   "main": "index.js",
-  "author": ["Eric Hartline, Reece Langerock"],
+  "author": [
+    "Eric Hartline, Reece Langerock"
+  ],
   "license": "MIT",
   "scripts": {
-    "start": "NODE_ENV=development webpack-dev-server",
+    "start": "SET NODE_ENV=development && webpack-dev-server",
     "build": "NODE_ENV=production webpack -p"
   },
   "devDependencies": {
@@ -33,9 +35,12 @@
     "webpack-dev-server": "^2.4.5"
   },
   "dependencies": {
+    "foundation-sites": "^6.3.1",
+    "jquery": "^3.2.1",
     "prop-types": "^15.5.10",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "react-router-dom": "^4.1.1"
+    "react-router-dom": "^4.1.1",
+    "script-loader": "^0.7.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ import {
 
 import Home from './containers/Home';
 import About from './containers/About';
-import Navigation from './containers/Navigation'
+import Navigation from './containers/Navigation';
 
 import reactLogo from './assets/React-icon.png';
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,3 +1,6 @@
+@import '~foundation-sites/scss/foundation';
+@include foundation-everything;
+
 .container {
     margin: auto;
     text-align: center;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,18 @@ module.exports = {
   },
   entry: [
     'react-hot-loader/patch',
+    'script-loader!jquery/dist/jquery.min.js',
+    'script-loader!foundation-sites/dist/js/foundation.min.js',
     path.join(__dirname, '/src/index.jsx'),
+  ],
+  externals: {
+    jquery: 'jQuery'
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      '$': 'jquery',
+      'jQuery': 'jquery'
+    })
   ],
   module: {
     loaders: [


### PR DESCRIPTION
I added Foundation to Webpack config and our main stylesheet, and it worked in stylizing the nav bar.

New dependencies: foundation-sites, jquery, script-loader.

I had to change the "start" line in package.json in order to work in Windows. Not sure why the formatting of the author array changed -- I didn't do that personally.